### PR TITLE
Bump Bix.Mixers ref to 0.1.4. Add generic tests.

### DIFF
--- a/BixMixersMixinDefinitions/IMixinDefinition.cs
+++ b/BixMixersMixinDefinitions/IMixinDefinition.cs
@@ -8,5 +8,6 @@ namespace BixMixersMixinDefinitions
         int Property { get; }
         List<string> Method(int arg0, params string[] args);
         event EventHandler<UnhandledExceptionEventArgs> AFunnyThingHappened;
+        string GenericMethod<T>(T input);
     }
 }

--- a/BixMixersMixinImplementations/MixinImplementation.cs
+++ b/BixMixersMixinImplementations/MixinImplementation.cs
@@ -59,5 +59,30 @@ namespace BixMixersMixinImplementations
             var eventHandler = NestedThingsHappened;
             if (eventHandler != null) { eventHandler(typeof(MixinImplementation), e); }
         }
+
+        public string GenericMethod<T>(T input)
+        {
+            return string.Format(
+                "Input has type {0} and string converted value {1}",
+                typeof(T).FullName,
+                input == null ? "<null>" : input.ToString());
+        }
+
+        public class NestedGenericType<TWeedleDee, TWeedleDum>
+        {
+            public NestedGenericType(TWeedleDee dee, TWeedleDum dum)
+            {
+                this.Dee = dee;
+                this.Dum = dum;
+            }
+
+            public TWeedleDee Dee { get; private set; }
+            public TWeedleDum Dum { get; private set; }
+        }
+
+        public NestedGenericType<string, T> GetAThing<T>(T thingDum)
+        {
+            return new NestedGenericType<string, T>("canned spam", thingDum);
+        }
     }
 }

--- a/BixMixersMixinTargets/BixMixersMixinTargets.csproj
+++ b/BixMixersMixinTargets/BixMixersMixinTargets.csproj
@@ -31,8 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bix.Mixers.Fody">
-      <HintPath>..\packages\Bix.Mixers.Fody.0.1.3.0\lib\net45\Bix.Mixers.Fody.dll</HintPath>
+    <Reference Include="Bix.Mixers.Fody, Version=0.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Bix.Mixers.Fody.0.1.4.0\lib\net45\Bix.Mixers.Fody.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BixMixersMixinTargets/packages.config
+++ b/BixMixersMixinTargets/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bix.Mixers.Fody" version="0.1.3.0" targetFramework="net45" />
+  <package id="Bix.Mixers.Fody" version="0.1.4.0" targetFramework="net45" />
   <package id="Fody" version="1.25.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/BixMixersSample/InterfaceMixinSample.cs
+++ b/BixMixersSample/InterfaceMixinSample.cs
@@ -29,6 +29,14 @@ namespace BixMixersSample
             Assert.That(target.Property, Is.EqualTo(int.MinValue));
             Assert.That(targetAsInterface.Property, Is.EqualTo(3209));
 
+            // show that a generic method call works
+            var expectedValue = string.Format("Input has type {0} and string converted value 42", typeof(int).FullName);
+            Assert.That(target.GenericMethod(42), Is.EqualTo(expectedValue));
+            expectedValue = string.Format("Input has type {0} and string converted value 42", typeof(long).FullName);
+            Assert.That(target.GenericMethod(42L), Is.EqualTo(expectedValue));
+            expectedValue = string.Format("Input has type {0} and string converted value forty-two", typeof(string).FullName);
+            Assert.That(target.GenericMethod("forty-two"), Is.EqualTo(expectedValue));
+
             // show that the event calls delegate as expected and that the method is called correctly
             var callCount = 0;
             EventHandler<UnhandledExceptionEventArgs> eventHandler = (sender, e) =>
@@ -72,11 +80,13 @@ namespace BixMixersSample
             Assert.That(nestedEventArgs.Things, Is.EqualTo(MixinTarget.Attributes.Nothing));
 
             // show that the static field acts as expected
+            MixinTarget.StaticField = 0;
             Assert.That(MixinTarget.StaticField, Is.EqualTo(0));
             MixinTarget.StaticField = 9;
             Assert.That(MixinTarget.StaticField, Is.EqualTo(9));
 
             // show that the static auto-property acts as expected
+            MixinTarget.StaticProperty = 0;
             Assert.That(MixinTarget.StaticProperty, Is.EqualTo(0));
             MixinTarget.StaticProperty = 5648;
             Assert.That(MixinTarget.StaticProperty, Is.EqualTo(5648));
@@ -100,6 +110,16 @@ namespace BixMixersSample
             length = MixinTarget.StaticMethod(null);
             Assert.That(staticCallCount, Is.EqualTo(1));
             Assert.That(length, Is.EqualTo(0));
+
+            // play around with a generic nested type
+            var nestedTarget = new MixinTarget.NestedGenericType<int, string>(42, "forty-two");
+            Assert.That(nestedTarget.Dee, Is.EqualTo(42));
+            Assert.That(nestedTarget.Dum, Is.EqualTo("forty-two"));
+
+            // more play, add in generic method with partially closed generic return type
+            var wibblyWobbly = target.GetAThing(989);
+            Assert.That(wibblyWobbly.Dee, Is.EqualTo("canned spam"));
+            Assert.That(wibblyWobbly.Dum, Is.EqualTo(989));
         }
     }
 }


### PR DESCRIPTION
Bix.Mixers 0.1.4 supports generics within mixin implementations. This is to bump the referenced NuGet version and add example tests showing generic support.
