### PR TITLE
Bump Bix.Mixers ref to 0.1.5. Add field intialize test.

### DIFF
--- a/BixMixersMixinImplementations/MixinImplementation.cs
+++ b/BixMixersMixinImplementations/MixinImplementation.cs
@@ -84,5 +84,12 @@ namespace BixMixersMixinImplementations
         {
             return new NestedGenericType<string, T>("canned spam", thingDum);
         }
+
+        public class NestedType
+        {
+            public int ObjectInitializableInt { get; set; }
+        }
+
+        public NestedType FieldWithObjectInitializer = new NestedType { ObjectInitializableInt = 300 };
     }
 }

--- a/BixMixersMixinTargets/BixMixersMixinTargets.csproj
+++ b/BixMixersMixinTargets/BixMixersMixinTargets.csproj
@@ -31,9 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bix.Mixers.Fody, Version=0.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Bix.Mixers.Fody, Version=0.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Bix.Mixers.Fody.0.1.4.0\lib\net45\Bix.Mixers.Fody.dll</HintPath>
+      <HintPath>..\packages\Bix.Mixers.Fody.0.1.5.0\lib\net45\Bix.Mixers.Fody.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BixMixersMixinTargets/packages.config
+++ b/BixMixersMixinTargets/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bix.Mixers.Fody" version="0.1.4.0" targetFramework="net45" />
+  <package id="Bix.Mixers.Fody" version="0.1.5.0" targetFramework="net45" />
   <package id="Fody" version="1.25.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/BixMixersSample/InterfaceMixinSample.cs
+++ b/BixMixersSample/InterfaceMixinSample.cs
@@ -120,6 +120,9 @@ namespace BixMixersSample
             var wibblyWobbly = target.GetAThing(989);
             Assert.That(wibblyWobbly.Dee, Is.EqualTo("canned spam"));
             Assert.That(wibblyWobbly.Dum, Is.EqualTo(989));
+
+            // show that a field that is initialized with an object initializer works
+            Assert.That(target.FieldWithObjectInitializer.ObjectInitializableInt, Is.EqualTo(300));
         }
     }
 }


### PR DESCRIPTION
Another version bump to address a couple of longstanding oddities with Bix.Mixers: field initialization works, and constructor logic, though still unsupported, is now detected and causes an exception.
