### PR TITLE
Bix.Mixers version bump. Add constructor support tests.

### DIFF
--- a/BixMixersMixinImplementations/MixinImplementation.cs
+++ b/BixMixersMixinImplementations/MixinImplementation.cs
@@ -6,6 +6,21 @@ namespace BixMixersMixinImplementations
 {
     public class MixinImplementation : IMixinDefinition
     {
+        static MixinImplementation()
+        {
+            MixinStaticConstructorInitializedValue = 8978;
+        }
+
+        public MixinImplementation()
+        {
+            ++MixinImplementationConstructorCallCount;
+            this.MixinConstructorInitializedValue = 9843;
+        }
+
+        public static int MixinStaticConstructorInitializedValue;
+        public int MixinConstructorInitializedValue;
+        public static int MixinImplementationConstructorCallCount;
+
         public int Property { get { return int.MinValue; } }
 
         int IMixinDefinition.Property { get { return Field; } }

--- a/BixMixersMixinTargets/BixMixersMixinTargets.csproj
+++ b/BixMixersMixinTargets/BixMixersMixinTargets.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>BixMixersMixinTargets</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>5776eaac</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>110021b7</NuGetPackageImportStamp>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bix.Mixers.Fody, Version=0.1.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Bix.Mixers.Fody.0.1.5.0\lib\net45\Bix.Mixers.Fody.dll</HintPath>
+    <Reference Include="Bix.Mixers.Fody">
+      <HintPath>..\packages\Bix.Mixers.Fody.0.1.7.0\lib\net45\Bix.Mixers.Fody.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -51,20 +50,20 @@
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\BixMixersMixinDefinitions\BixMixersMixinDefinitions.csproj">
       <Project>{281bdf73-4eb8-4273-942f-c0a5bd073223}</Project>
       <Name>BixMixersMixinDefinitions</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.1.26.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.26.0\build\Fody.targets')" />
+  <Import Project="..\packages\Fody.1.26.1\build\Fody.targets" Condition="Exists('..\packages\Fody.1.26.1\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.26.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.26.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.26.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.26.1\build\Fody.targets'))" />
   </Target>
 </Project>

--- a/BixMixersMixinTargets/MixinTarget.cs
+++ b/BixMixersMixinTargets/MixinTarget.cs
@@ -6,6 +6,24 @@ namespace BixMixersMixinTargets
     [InterfaceMixin(typeof(IMixinDefinition))]
     public class MixinTarget
     {
+        static MixinTarget()
+        {
+            NonMixinStaticValue = 34;
+        }
+
+        public MixinTarget() : this(532) { ++InstanceConstructorCalledCount; }
+
+        public MixinTarget(int value)
+        {
+            ++InstanceConstructorCalledCount;
+            this.NonMixinValue = value;
+        }
+
         public int NonMixinProperty { get { return 5; } }
+
+        public static int NonMixinStaticValue;
+        public int NonMixinValue;
+
+        public static int InstanceConstructorCalledCount;
     }
 }

--- a/BixMixersMixinTargets/packages.config
+++ b/BixMixersMixinTargets/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bix.Mixers.Fody" version="0.1.5.0" targetFramework="net45" />
-  <package id="Fody" version="1.26.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Bix.Mixers.Fody" version="0.1.7.0" targetFramework="net451" />
+  <package id="Fody" version="1.26.1" targetFramework="net451" developmentDependency="true" />
 </packages>

--- a/BixMixersSample/InterfaceMixinSample.cs
+++ b/BixMixersSample/InterfaceMixinSample.cs
@@ -11,8 +11,27 @@ namespace BixMixersSample
         [Test]
         public void MixinWorksAsExpected()
         {
+            // reset a couple of static value counters that are used in the test in case the test runs multiple times
+            MixinTarget.InstanceConstructorCalledCount = 0;
+            MixinTarget.MixinImplementationConstructorCallCount = 0;
+
+            // create the target object and an interface reference to it
             var target = new MixinTarget();
             var targetAsInterface = target as IMixinDefinition;
+
+            // show that static constructor worked as expected
+            Assert.That(MixinTarget.NonMixinStaticValue, Is.EqualTo(34));
+            Assert.That(MixinTarget.MixinStaticConstructorInitializedValue, Is.EqualTo(8978));
+
+            // show that constructor worked as expected
+            Assert.That(target.NonMixinValue, Is.EqualTo(532));
+            Assert.That(target.MixinConstructorInitializedValue, Is.EqualTo(9843));
+
+            // the called constructor chained into another constructor, so this should be two
+            Assert.That(MixinTarget.InstanceConstructorCalledCount, Is.EqualTo(2));
+
+            // even though two target instance constructors ran, the code for the mixin implemenation constructor will have only run once
+            Assert.That(MixinTarget.MixinImplementationConstructorCallCount, Is.EqualTo(1));
 
             // show that the interface is implemented
             Assert.That(target, Is.InstanceOf<IMixinDefinition>());


### PR DESCRIPTION
New tests show added support for static and instance constructor code cloning in Bix.Mixers.
